### PR TITLE
Add babelrc false to webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
 				use: {
 					loader: 'babel-loader',
 					options: {
+						babelrc: false,
 						presets: [ '@babel/preset-env', '@babel/preset-react' ],
 						plugins: [
 							[


### PR DESCRIPTION
@mattheu I've added `babelrc: false` to the webpack config. We had issues with `yarn build` not working and it was because it was traversing up the tree and took the one from our repo.