### PR TITLE
Bundle the API client extensions

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -13,6 +13,8 @@ function setup() {
  * Enqueue assets in the editor.
  */
 function enqueue_block_editor_assets() {
+	extend_wp_api_backbone_client();
+
 	wp_enqueue_script(
 		'hm-gb-tools-editor',
 		HM_GB_TOOLS_URL . '/build/editor.bundle.js',
@@ -82,4 +84,40 @@ function get_post_type_taxonomies() {
 	}, $post_types ) );
 
 	return apply_filters( 'hm_gb_tools_post_type_taxonomies', $data );
+}
+
+
+/**
+ * Extend wp-api Backbone client with methods to look up the REST API endpoints for all post types.
+ *
+ * This is temporary while waiting for #41111 in core.
+ *
+ * @link https://core.trac.wordpress.org/ticket/41111
+ */
+function extend_wp_api_backbone_client() {
+	// Post Types Mapping.
+	$post_type_rest_base_mapping = [];
+	foreach ( get_post_types( array(), 'objects' ) as $post_type_object ) {
+		$rest_base = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;
+		$post_type_rest_base_mapping[ $post_type_object->name ] = $rest_base;
+	}
+
+	// Taxonomies Mapping.
+	$taxonomy_rest_base_mapping = [];
+	foreach ( get_taxonomies( array(), 'objects' ) as $taxonomy_object ) {
+		$rest_base = ! empty( $taxonomy_object->rest_base ) ? $taxonomy_object->rest_base : $taxonomy_object->name;
+		$taxonomy_rest_base_mapping[ $taxonomy_object->name ] = $rest_base;
+	}
+
+	$script  = sprintf( 'wp.api.postTypeRestBaseMapping = %s;', wp_json_encode( $post_type_rest_base_mapping ) );
+	$script .= sprintf( 'wp.api.taxonomyRestBaseMapping = %s;', wp_json_encode( $taxonomy_rest_base_mapping ) );
+	$script .= <<<JS
+		wp.api.getPostTypeRoute = function( postType ) {
+			return wp.api.postTypeRestBaseMapping[ postType ];
+		};
+		wp.api.getTaxonomyRoute = function( taxonomy ) {
+			return wp.api.taxonomyRestBaseMapping[ taxonomy ];
+		};
+JS;
+	wp_add_inline_script( 'wp-api', $script );
 }


### PR DESCRIPTION
I'd like to move away from using the backbone API client. But in the mean time, we need to hotfix this as its been removed from GB and is causing the modal to break.