### PR TITLE
FSA-1039 Cover block auto lead media pin feature fixes

### DIFF
--- a/js/components/post-select/button.js
+++ b/js/components/post-select/button.js
@@ -12,19 +12,38 @@ const { __ } = wp.i18n;
 class PostSelectButton extends React.Component {
 	state = { modalVisible: false };
 
+	showPromptToDisableAutoLeadMedia() {
+		const userActionTaken = confirm(`New Post cannot be pinned here when Auto Lead Media option is enabled. Do you want to disable Auto Lead Media option?`);
+		console.log( 'userActionTaken', userActionTaken );
+		if( userActionTaken ) {
+			const { onDisableAutoLeadMedia } = this.props;
+			onDisableAutoLeadMedia();
+		}
+	}
+	checkForAutoLeadMediaOption( enableAutoLeadMedia ) {
+		enableAutoLeadMedia ? 
+			this.showPromptToDisableAutoLeadMedia() : 
+			this.toggleModal( true );
+	}
+
+	toggleModal( modalState ) { 
+		this.setState( { modalVisible: modalState } );
+	}
+
 	render(){
 		const {
 			children,
 			onSelect,
 			value = [],
 			btnProps = {},
+			enableAutoLeadMedia
 		} = this.props;
 
 		const { modalVisible } = this.state;
 
-		const onClose = () => this.setState( { modalVisible: false } );
+		const onClose = () => this.toggleModal( false );
 
-		btnProps.onClick = () => this.setState( { modalVisible: true } );
+		btnProps.onClick = () => this.checkForAutoLeadMediaOption( enableAutoLeadMedia );
 
 		return <div className="post-select">
 			<Button { ...btnProps }>{ children }</Button>


### PR DESCRIPTION
[FSA-1039](https://humanmade.atlassian.net/browse/FSA-1039) - Custom feature added as Auto lead media, where admin should not be able to pin the post in cover story, Added condition to handle


*I have:*
- [ ] Written doc blocks and inline documentation on all new changes
- [x] Added the Jira reference as a prefix to the title of the PR
- [ ] Notes on how-to-test supplied in issue description on Jira
- [ ] WP CLI commands supplied in issue description on Jira
- [ ] As a developer, I've tested this on www-development.foxsportsasia.com
