### PR TITLE
Image control fixes

### DIFF
--- a/css/editor.scss
+++ b/css/editor.scss
@@ -35,20 +35,8 @@
 }
 
 .hm-link-control {
-	.editor-url-input input {
-		border: 1px solid #ddd;
-		box-shadow: inset 0 1px 2px rgba( 0, 0, 0, 0.07 );
-		background-color: #fff;
-		color: #32373c;
-		outline: none;
-		transition: 0.05s border-color ease-in-out;
-		padding: 6px 8px;
+	.block-editor-url-input input {
 		max-width: 100%;
-
-		&:focus {
-			border-color: #5b9dd9;
-			box-shadow: 0 0 2px rgba( 30, 140, 190, 0.8 );
-		}
 	}
 
 	.components-spinner {
@@ -60,6 +48,7 @@
 .hm-image-control {
 	&__img-container {
 		position: relative;
+		display: inline-block;
 		margin-bottom: 10px;
 
 		&:after {

--- a/css/editor.scss
+++ b/css/editor.scss
@@ -60,7 +60,6 @@
 .hm-image-control {
 	&__img-container {
 		position: relative;
-		float: left;
 		margin-bottom: 10px;
 
 		&:after {

--- a/js/controls/image.js
+++ b/js/controls/image.js
@@ -46,7 +46,7 @@ const ImageControl = ( {
 		<div className="hm-image-control__actions">
 			<MediaUpload
 				render={ ( { open } ) => (
-					<Button isLarge onClick={ open }>
+					<Button isLarge isSecondary onClick={ open }>
 						{ value ? __( 'Change' ) : __( 'Select' ) }
 					</Button>
 				) }
@@ -58,6 +58,7 @@ const ImageControl = ( {
 			{ !! value && (
 				<Button
 					isLarge
+					isSecondary
 					style={ { marginLeft: '8px' } }
 					onClick={ () => onChange() }
 				>{ __( 'Remove' ) }</Button>

--- a/js/controls/image.js
+++ b/js/controls/image.js
@@ -86,13 +86,12 @@ ImageControl.propTypes = {
 };
 
 export default withSelect( ( select, ownProps ) => {
-	const { getEntityRecord } = select( 'core' );
+	const { getMedia } = select( 'core' );
 	const { value } = ownProps;
-	const image = value ? getEntityRecord( 'root', 'media', value ) : null;
+	const image = value ? getMedia( value ) : null;
 
 	return {
 		image,
 		isLoading: !! value && ! image,
 	};
 } )( ImageControl );
-

--- a/js/controls/image.js
+++ b/js/controls/image.js
@@ -60,7 +60,7 @@ const ImageControl = ( {
 					isLarge
 					isSecondary
 					style={ { marginLeft: '8px' } }
-					onClick={ () => onChange() }
+					onClick={ () => onChange( null ) }
 				>{ __( 'Remove' ) }</Button>
 			) }
 		</div>


### PR DESCRIPTION
The image control is not working with newer versions of Gutenberg. 

* Style updates
* Use `getMedia` instead of `getEntityRecord`