### PR TITLE
Add .build-script

### DIFF
--- a/.build-script
+++ b/.build-script
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+#install latest version of node
+nvm install 12
+
+npm install
+npm run build


### PR DESCRIPTION
## Description

In order to use this in the HM Playbook we need this repo to be added to the hmn.md network as a sub module. As this repo does not also contain built files, we need an additional script so that when it's deployed to hmn.md, the files are built.

The addition of nvm and setting Node 12 is because some of the older themes on the hmn.md network are set to use Node 8 and if they were built/deployed last the version of Node used is 8. This ensures that Node 12 is always used to build these files.