### PR TITLE
Remove isLarge from Button to remove console errors

### DIFF
--- a/js/controls/image.js
+++ b/js/controls/image.js
@@ -46,7 +46,7 @@ const ImageControl = ( {
 		<div className="hm-image-control__actions">
 			<MediaUpload
 				render={ ( { open } ) => (
-					<Button isLarge isSecondary onClick={ open }>
+					<Button isSecondary onClick={ open }>
 						{ value ? __( 'Change' ) : __( 'Select' ) }
 					</Button>
 				) }
@@ -57,7 +57,6 @@ const ImageControl = ( {
 
 			{ !! value && (
 				<Button
-					isLarge
 					isSecondary
 					style={ { marginLeft: '8px' } }
 					onClick={ () => onChange( null ) }

--- a/js/controls/post.js
+++ b/js/controls/post.js
@@ -21,7 +21,6 @@ const PostControl = ( {
 	btnText,
 } ) => {
 	postSelectProps.btnProps = postSelectProps.btnProps || {};
-	postSelectProps.btnProps.isLarge = true;
 	postSelectProps.btnProps.isSecondary = true;
 
 	return (

--- a/js/post-select/components/browse-filters.js
+++ b/js/post-select/components/browse-filters.js
@@ -67,7 +67,6 @@ const PostBrowseFilters = ( {
 		) ) }
 
 		<Button
-			isLarge
 			isPrimary
 			type="submit"
 		>

--- a/js/post-select/components/browse.js
+++ b/js/post-select/components/browse.js
@@ -42,7 +42,6 @@ const PostSelectBrowse = props => {
 							<Button
 								className="prev-page"
 								disabled={ isLoading }
-								isLarge
 								onClick={ () => onPrevPostsPage() }
 							>
 								Previous page
@@ -67,7 +66,6 @@ const PostSelectBrowse = props => {
 
 						{ hasMore && <Button
 							className="next-page"
-							isLarge
 							onClick={ () => onNextPostsPage() }
 						>Next page</Button> }
 					</Fragment>

--- a/js/post-select/components/post-select-modal.js
+++ b/js/post-select/components/post-select-modal.js
@@ -30,20 +30,17 @@ const PostSelectModal = props => {
 	const modalToolbar = (
 		<Fragment>
 			<Button
-				isLarge
 				isPrimary
 				onClick={ () => onSelect() }
 			>Select</Button>
 			{ contentState !== 'selection' && (
 				<Button
-					isLarge
 					isPrimary={ false }
 					onClick={ () => onChangeContentState( 'selection' ) }
 				>{ __( 'Manage current selection', 'hm-gb-tools' ) }</Button>
 			) }
 			{ contentState !== 'browse' && (
 				<Button
-					isLarge
 					isPrimary={ false }
 					onClick={ () => onChangeContentState( 'browse' ) }
 				>{ __( 'Browse posts', 'hm-gb-tools' ) }</Button>


### PR DESCRIPTION
The Button core component no longer supports `isLarge`:
https://github.com/WordPress/gutenberg/commit/7733aea1f922c8b522a052c4e6123b712911480d#diff-1204d0def76e28ff29950465cc842e3fafcee022c7e97c76fa5cf5baa4c4505a

This means that several parts of the code (removed in this commit) throw a console error about React being unable to add `isLarge` to a DOM element. Removing these references removes the error, and doesn't seem to have any effect on the operation of the plugin.