### PR TITLE
Add release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/release
 
 # misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -45,13 +45,12 @@ HM Gutenberg Tools then exposes all functionality globally as `window.hm`. You c
 
 ## Releasing a new version.
 
-There is a bash script that can be run to release a new version from the master branch.
+1. Update the version numbers in `plugin.php` and `package.json`.
+2. Add the changelog to the readme for the new version.
+3. Commit your changes to master and push. 
+4. Run the bash script: `./release.sh v1.2.3`
 
-```
-./release.sh v1.2.3
-```
-
-This will sync the the build branch with master, build assets, and publish a tag.
+The script will sync the the build branch with master, build assets and commit the changes, and publish a new tagged release.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ HM Gutenberg Tools then exposes all functionality globally as `window.hm`. You c
 * `npm run watch` Watches for changes and builds development versions of the code.
 * `npm run lint` Lints your JS and fixes your code.
 
+## Releasing a new version.
+
+There is a bash script that can be run to release a new version from the master branch.
+
+```
+./release.sh v1.2.3
+```
+
+This will sync the the build branch with master, build assets, and publish a tag.
+
 ## Changelog
 
 ### v1.1.0

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ HM Gutenberg Tools then exposes all functionality globally as `window.hm`. You c
 3. Commit your changes to master and push. 
 4. Run the bash script: `./release.sh v1.2.3`
 
-The script will sync the the build branch with master, build assets and commit the changes, and publish a new tagged release.
+The script will sync the the build branch with master, build assets and commit the changes, and publish a new tagged version.
 
 ## Changelog
 

--- a/release.sh
+++ b/release.sh
@@ -13,7 +13,7 @@ echo "Releasing version $1";
 if [ -d "$SCRIPT_DIR/release" ] || [ ! -d "$SCRIPT_DIR/release/.git" ]
 	then
 		# Cleanup and clone fresh copy of repo on build branch.
-		rm -r "$SCRIPT_DIR/release";
+		rm -rf "$SCRIPT_DIR/release";
 		git clone --recursive --branch build git@github.com:humanmade/hm-gutenberg-tools.git release
 	else
 		# Cleanup any changes and reset to build branch.

--- a/release.sh
+++ b/release.sh
@@ -25,7 +25,7 @@ fi
 # Merge in latest from master, install dependencies and build.
 cd "${SCRIPT_DIR}/release" || exit;
 git merge origin/master --no-edit;
-npm install;
+npm ci;
 npm run build;
 
 # Stage changes ready for commit.

--- a/release.sh
+++ b/release.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-RELEASE_DIR='release';
 
 if [ -z "$1" ]
 	then
@@ -14,17 +13,17 @@ echo "Releasing version $1";
 if [ -d "$SCRIPT_DIR/release" ] && [ ! -d "$SCRIPT_DIR/release/.git" ]
 	then
 		# Cleanup and clone fresh copy of repo on build branch.
-		rm -r "$SCRIPT_DIR/$RELEASE_DIR";
-		git clone --recursive --branch build git@github.com:humanmade/hm-gutenberg-tools.git ${RELEASE_DIR}
+		rm -r "$SCRIPT_DIR/release";
+		git clone --recursive --branch build git@github.com:humanmade/hm-gutenberg-tools.git release
 	else
 		# Cleanup any changes and reset to build branch.
-		cd "${SCRIPT_DIR}/${RELEASE_DIR}";
+		cd "${SCRIPT_DIR}/release" || exit;
 		git clean -fd;
 		git reset origin/build --hard;
 fi
 
 # Merge in latest from master, install dependencies and build.
-cd "${SCRIPT_DIR}/${RELEASE_DIR}";
+cd "${SCRIPT_DIR}/release" || exit;
 git merge origin/master --no-edit;
 npm install;
 npm run build;
@@ -35,6 +34,6 @@ git add -f build;
 
 # Commit to build branch and tag release.
 git commit -m "Build release $1";
-git tag ${1};
+git tag "${1}";
 git push origin build;
 git push --tags;

--- a/release.sh
+++ b/release.sh
@@ -10,7 +10,7 @@ fi
 
 echo "Releasing version $1";
 
-if [ -d "$SCRIPT_DIR/release" ] || [ ! -d "$SCRIPT_DIR/release/.git" ]
+if [ ! -d "$SCRIPT_DIR/release" ] || [ -d "$SCRIPT_DIR/release" ] && [ ! -d "$SCRIPT_DIR/release/.git" ]
 	then
 		# Cleanup and clone fresh copy of repo on build branch.
 		rm -rf "$SCRIPT_DIR/release";

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+RELEASE_DIR='release';
+
+if [ -z "$1" ]
+	then
+		echo "Error: Must pass version string (e.g. v1.2.3) as first parameter.";
+		exit 0;
+fi
+
+echo "Releasing version $1";
+
+if [ -d "$SCRIPT_DIR/release" ] && [ ! -d "$SCRIPT_DIR/release/.git" ]
+	then
+		# Cleanup and clone fresh copy of repo on build branch.
+		rm -r "$SCRIPT_DIR/$RELEASE_DIR";
+		git clone --recursive --branch build git@github.com:humanmade/hm-gutenberg-tools.git ${RELEASE_DIR}
+	else
+		# Cleanup any changes and reset to build branch.
+		cd "${SCRIPT_DIR}/${RELEASE_DIR}";
+		git clean -fd;
+		git reset origin/build --hard;
+fi
+
+# Merge in latest from master, install dependencies and build.
+cd "${SCRIPT_DIR}/${RELEASE_DIR}";
+git merge origin/master --no-edit;
+npm install;
+npm run build;
+
+# Stage changes ready for commit.
+git add .;
+git add -f build;
+
+# Commit to build branch and tag release.
+git commit -m "Release $1";
+git tag ${1};
+git push origin build;
+git push --tags;

--- a/release.sh
+++ b/release.sh
@@ -34,7 +34,7 @@ git add .;
 git add -f build;
 
 # Commit to build branch and tag release.
-git commit -m "Release $1";
+git commit -m "Build release $1";
 git tag ${1};
 git push origin build;
 git push --tags;

--- a/release.sh
+++ b/release.sh
@@ -33,7 +33,7 @@ git add .;
 git add -f build;
 
 # Commit to build branch and tag release.
-git commit -m "Build release $1";
+git commit -m "Build version $1";
 git tag "${1}";
 git push origin build;
 git push --tags;

--- a/release.sh
+++ b/release.sh
@@ -10,7 +10,7 @@ fi
 
 echo "Releasing version $1";
 
-if [ -d "$SCRIPT_DIR/release" ] && [ ! -d "$SCRIPT_DIR/release/.git" ]
+if [ -d "$SCRIPT_DIR/release" ] || [ ! -d "$SCRIPT_DIR/release/.git" ]
 	then
 		# Cleanup and clone fresh copy of repo on build branch.
 		rm -r "$SCRIPT_DIR/release";


### PR DESCRIPTION
Add a script to release a new version. 

What it does.
* Clones another copy of the repo in a directory to `release`, to ensure nothing is overwritten or committed accidentally.
* Builds.
* Commits changes, including the `build` files which are normally ignored. 
* Commits and tags the release. 
* Pushes/publishes. 

This is an MVP, would be nice to validate version numbers, handle releasing minor versions from a different branch etc.. but will do for now. 

