### PR TITLE
Fix error when removing filter from post select dialog

### DIFF
--- a/js/post-select/components/form-field-select.js
+++ b/js/post-select/components/form-field-select.js
@@ -25,7 +25,7 @@ const FormFieldSelect = ( {
 			maxMenuHeight={ 300 }
 			options={ options }
 			placeholder={ placeholder }
-			onChange={ options => onChange( options.map( option => option.value ) ) }
+			onChange={ options => onChange( ( options || [] ).map( option => option.value ) ) }
 			onInputChange={ s => onUpdateSearch && onUpdateSearch( s ) }
 			onMenuScrollToBottom={ () => onFetchMoreTerms && onFetchMoreTerms() }
 		/>


### PR DESCRIPTION
I ran into an issue where when removing a filter from the post select dialog such that no filter terms were left, it would throw an error about `Cannot read property 'map' of null`. It looks like this is a the result of the `options` value in the `FormFieldSelect` ending up as some falsy value. 

This PR is a quick fix--I couldn't track down where the falsy value was coming from. This fix was good enough for my purposes in the project I'm using this on, but I wanted to push it back upstream. A more robust fix would probably figure out what's passing a falsy value to this component and stop that from happening.