### PR TITLE
Add support for user-defined filters

### DIFF
--- a/js/post-select/components/browse-filters.js
+++ b/js/post-select/components/browse-filters.js
@@ -82,7 +82,7 @@ PostBrowseFilters.defaultProps = {
 
 PostBrowseFilters.propTypes = {
 	value: PropTypes.objectOf(
-		PropTypes.oneOf( [
+		PropTypes.oneOfType( [
 			PropTypes.arrayOf( PropTypes.number ),
 			PropTypes.string,
 		] )

--- a/js/post-select/components/browse-filters.js
+++ b/js/post-select/components/browse-filters.js
@@ -81,7 +81,12 @@ PostBrowseFilters.defaultProps = {
 };
 
 PostBrowseFilters.propTypes = {
-	value: PropTypes.object,
+	value: PropTypes.objectOf(
+		PropTypes.oneOf( [
+			PropTypes.arrayOf( PropTypes.number ),
+			PropTypes.string,
+		] )
+	),
 	onUpdateFilters: PropTypes.func.isRequired,
 	terms: PropTypes.arrayOf( PropTypes.object ),
 };

--- a/js/post-select/components/browse.js
+++ b/js/post-select/components/browse.js
@@ -11,6 +11,7 @@ const { Spinner } = wp.components;
 
 const PostSelectBrowse = props => {
 	const {
+		filters,
 		posts,
 		isLoading,
 		selection,
@@ -28,6 +29,7 @@ const PostSelectBrowse = props => {
 		<div className="menu-container">
 			<div className="menu">
 				<PostSelectBrowseFilters
+					filters={ filters }
 					postTypes={ postTypes }
 					termFilters={ termFilters }
 					onApplyFilters={ filters => onApplyFilters( filters ) }
@@ -76,6 +78,7 @@ const PostSelectBrowse = props => {
 };
 
 PostSelectBrowse.propTypes = {
+	filters: PropTypes.objectOf( PropTypes.arrayOf( PropTypes.number ) ),
 	postTypes: PropTypes.arrayOf( PropTypes.string ).isRequired,
 	selection: PropTypes.array,
 	onToggleSelected: PropTypes.func.isRequired,

--- a/js/post-select/components/form-field-select.js
+++ b/js/post-select/components/form-field-select.js
@@ -13,6 +13,7 @@ const FormFieldSelect = ( {
 	onFetchMoreTerms,
 	onUpdateSearch,
 	placeholder,
+	value,
 } ) => (
 	<FormRow
 		label={ label }
@@ -25,7 +26,8 @@ const FormFieldSelect = ( {
 			maxMenuHeight={ 300 }
 			options={ options }
 			placeholder={ placeholder }
-			onChange={ options => onChange( ( options || [] ).map( option => option.value ) ) }
+			value={ value }
+			onChange={ onChange }
 			onInputChange={ s => onUpdateSearch && onUpdateSearch( s ) }
 			onMenuScrollToBottom={ () => onFetchMoreTerms && onFetchMoreTerms() }
 		/>
@@ -36,6 +38,13 @@ FormFieldSelect.propTypes = {
 	fieldId: PropTypes.string.isRequired,
 	label: PropTypes.string.isRequired,
 	placeholder: PropTypes.string.isRequired,
+	value: PropTypes.arrayOf( PropTypes.shape( {
+		label: PropTypes.string.isRequired,
+		value: PropTypes.oneOfType( [
+			PropTypes.string,
+			PropTypes.number,
+		] ).isRequired,
+	} ) ),
 	onChange: PropTypes.func.isRequired,
 	options: PropTypes.arrayOf( PropTypes.shape( {
 		label: PropTypes.string.isRequired,

--- a/js/post-select/components/post-select-modal.js
+++ b/js/post-select/components/post-select-modal.js
@@ -12,6 +12,7 @@ const { __ } = wp.i18n;
 
 const PostSelectModal = props => {
 	const {
+		filters,
 		modalTitle,
 		postType,
 		onSelect,
@@ -52,6 +53,7 @@ const PostSelectModal = props => {
 		<Fragment>
 			{ ( contentState === 'browse' ) && (
 				<PostSelectBrowse
+					filters={ filters }
 					postType={ postType }
 					selection={ selection }
 					termFilters={ termFilters }
@@ -88,6 +90,7 @@ PostSelectModal.defaultProps = {
 };
 
 PostSelectModal.propTypes = {
+	filters: PropTypes.objectOf( PropTypes.arrayOf( PropTypes.number ) ),
 	postType: PropTypes.array.isRequired,
 	modalTitle: PropTypes.string,
 	onSelect: PropTypes.func.isRequired,

--- a/js/post-select/containers/browse-filters.js
+++ b/js/post-select/containers/browse-filters.js
@@ -12,9 +12,10 @@ const { withSelect } = wp.data;
 class PostBrowseFiltersContainer extends React.Component {
 	constructor( props ) {
 		super( props );
+		const { filters } = props;
 
 		this.state = {
-			filters: {},
+			filters: { ...filters },
 		};
 	}
 
@@ -37,6 +38,7 @@ class PostBrowseFiltersContainer extends React.Component {
 }
 
 PostBrowseFiltersContainer.propTypes = {
+	filters: PropTypes.objectOf( PropTypes.arrayOf( PropTypes.number ) ),
 	onApplyFilters: PropTypes.func.isRequired,
 	termFilters: PropTypes.arrayOf( PropTypes.string ),
 };

--- a/js/post-select/containers/browse.js
+++ b/js/post-select/containers/browse.js
@@ -12,10 +12,11 @@ const { postSelectEndpoint } = window.hmGbToolsData;
 class PostSelectBrowse extends React.Component {
 	constructor( props ) {
 		super( props );
+		const { filters } = props;
 
 		this.state = {
 			posts: [],
-			filters: {},
+			filters: { ...filters },
 			page: 1,
 			isLoading: false,
 			hasPrev: false,
@@ -71,11 +72,12 @@ class PostSelectBrowse extends React.Component {
 	}
 
 	render() {
-		const { posts, hasPrev, hasMore, isLoading } = this.state;
+		const { filters, posts, hasPrev, hasMore, isLoading } = this.state;
 		const { selection, onToggleSelected, termFilters, postType } = this.props;
 
 		return (
 			<Browse
+				filters={ filters }
 				hasMore={ hasMore }
 				hasPrev={ hasPrev }
 				isLoading={ isLoading }
@@ -111,6 +113,7 @@ class PostSelectBrowse extends React.Component {
 }
 
 PostSelectBrowse.propTypes = {
+	filters: PropTypes.objectOf( PropTypes.arrayOf( PropTypes.number ) ),
 	postType: PropTypes.arrayOf( PropTypes.string ).isRequired,
 	selection: PropTypes.arrayOf( PropTypes.object ).isRequired,
 	onToggleSelected: PropTypes.func.isRequired,

--- a/js/post-select/containers/post-select-modal.js
+++ b/js/post-select/containers/post-select-modal.js
@@ -49,6 +49,7 @@ class PostSelectModalContainer extends React.Component {
 
 	render() {
 		const {
+			filters,
 			onClose,
 			modalTitle,
 			termFilters,
@@ -66,6 +67,7 @@ class PostSelectModalContainer extends React.Component {
 		return (
 			<PostSelectModal
 				contentState={ contentState }
+				filters={ filters }
 				isLoading={ isLoadingSelection }
 				modalRef={ el => this.modalElement = el }
 				modalTitle={ modalTitle }
@@ -120,6 +122,7 @@ PostSelectModalContainer.defaultProps = {
 };
 
 PostSelectModalContainer.propTypes = {
+	filters: PropTypes.objectOf( PropTypes.arrayOf( PropTypes.number ) ),
 	postType: PropTypes.oneOfType( [
 		PropTypes.string,
 		PropTypes.array,

--- a/js/post-select/containers/term-select-form-field.js
+++ b/js/post-select/containers/term-select-form-field.js
@@ -19,6 +19,7 @@ class TermSelect extends React.Component {
 			isLoading: false,
 			page: 1,
 			hasMore: false,
+			value: [],
 		};
 	}
 
@@ -50,15 +51,20 @@ class TermSelect extends React.Component {
 			path: addQueryArgs( `wp/v2/${restBase}/`, query ),
 			signal: this.fetchPostAbortController.signal,
 		} ).then( ( [ terms, headers ] ) => {
+			const { value } = this.props;
+
 			const newOptions = _uniqBy( [ ...options, ...terms.map( term => ( {
 				value: term.id,
 				label: term.name,
 			} ) ) ], 'value' );
 
+			const newValue = value.map( id => newOptions.find( option => option.value === id ) ).filter( Boolean );
+
 			this.setState( {
 				options: newOptions,
 				hasMore: parseInt( headers['x-wp-totalpages'], 10 ) > page,
 				isLoading: false,
+				value: newValue,
 			} );
 		} );
 	}
@@ -88,7 +94,7 @@ class TermSelect extends React.Component {
 			search: null,
 			page: 1,
 		} );
-		onChange( value );
+		onChange( ( value || [] ).map( option => option.value ) );
 	}
 
 	render() {
@@ -97,8 +103,8 @@ class TermSelect extends React.Component {
 
 		return (
 			<FormFieldSelect
-				{ ...this.state }
 				{ ...this.props }
+				{ ...this.state }
 				fieldId={ this.props.fieldId }
 				label={ labelText }
 				placeholder={ labelText  }
@@ -110,10 +116,15 @@ class TermSelect extends React.Component {
 	}
 }
 
+TermSelect.defaultProps = {
+	value: [],
+};
+
 TermSelect.propTypes = {
 	fieldId: PropTypes.string.isRequired,
 	label: PropTypes.string.isRequired,
 	restBase: PropTypes.string.isRequired,
+	value: PropTypes.arrayOf( PropTypes.number ),
 	onChange: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
This PR looks massive, but in fact it doesn't do more than adding support for a `filters` prop on the `PostSelectButton` (and thus also `PostSelectModal`). By using this, you can set initial filters, which means a combination of taxonomy (rest base) and term IDs.
In addition to that, you could also ensure that `termFilters` is set to an empty array, if all you wanted is to allow selecting from a set list of posts (according to one or more filter combinations).

As you can see, that one property, `filters` ripples down to all sorts of containers and components, which might be an indicator for a to-be-improved data flow. Also, the `Select` component (from `react-select`) was uncontrolled. So, in order for us to pre-define one or more options to be initially selected, I had to change what data gets passed from the select; this was just the ID, but now we need the `option` object.