### PR TITLE
Add thumbnail option

### DIFF
--- a/css/components/_post-select-modal.scss
+++ b/css/components/_post-select-modal.scss
@@ -88,7 +88,6 @@
 
 .post-list-item {
 	box-sizing: border-box;
-	padding: 10px 20px;
 	margin: 0;
 	border-bottom: 1px solid #e2e4e7;
 	display: block;
@@ -96,6 +95,10 @@
 	text-align: left;
 	background: white;
 	position: relative;
+
+	&--inner {
+		padding: 10px 20px;
+	}
 
 	&--meta {
 		color: #666;
@@ -105,17 +108,21 @@
 		}
 	}
 
+	&--image {
+		width: 75px;
+		height: 75px;
+	}
+
 	.components-spinner {
 		float: none;
 		display: block;
 		margin: 16px;
 	}
 
-	> label {
+	> label,
+	&--selection {
 		font-size: inherit;
-		display: block;
-		margin: -10px -20px;
-		padding: 10px 20px;
+		display: flex;
 		position: relative;
 
 		&:focus,

--- a/inc/endpoints/class-post-select-controller.php
+++ b/inc/endpoints/class-post-select-controller.php
@@ -154,6 +154,7 @@ class Post_Select_Controller extends WP_REST_Controller {
 			'status' => $post->post_status,
 			'link' => get_permalink( $post->ID ),
 			'author' => absint( $post->post_author ),
+			'thumbnail' => apply_filters( 'hm_gb_tools_item_thumbnail_id', null, $post, $request ),
 		];
 
 		// For drafts, `post_date_gmt` may not be set, indicating that the

--- a/js/post-select/components/post-list-item.js
+++ b/js/post-select/components/post-list-item.js
@@ -6,21 +6,33 @@ import wp from 'wp';
 
 const { __ }  = wp.i18n;
 
-const PostListItem = ( { post, author, postTypeObject, isSelected, onToggleSelected } ) => (
-	<li className={ classNames( 'post-list-item', { 'post-list-item--selected': isSelected } ) }>
+const PostListItem = ( { post, author, thumbnail, postTypeObject, isSelected, onToggleSelected } ) => (
+	<li className={ classNames( 'post-list-item', {
+		'post-list-item--selected': isSelected,
+		'post-list-item--has-thumbnail': thumbnail,
+	} ) }>
 		<label htmlFor={ `select-post-${post.id}` }>
-			<input
-				checked={ isSelected }
-				className="screen-reader-text"
-				id={ `select-post-${post.id}` }
-				type="checkbox"
-				onChange={ () => onToggleSelected() }
-			/>
-			<h2 dangerouslySetInnerHTML={ { __html: post.title.rendered } } />
-			<div className="post-list-item--meta">
-				{ postTypeObject && ( <span><b>{ __( 'Type:', 'hm-gb-tools' ) }</b> { postTypeObject.labels.singular_name }</span> ) }
-				<span><b>{ __( 'Published:', 'hm-gb-tools' ) }</b> { moment( post.date_gmt ).format( 'Do MMM, YYYY' ) }</span>
-				{ author && ( <span><b>Author:</b> { author.name }</span> ) }
+			{ thumbnail
+				? <img
+					alt={ post.title.rendered }
+					className="post-list-item--image"
+					src={ thumbnail.media_details.sizes.thumbnail.source_url }
+				/>
+				: '' }
+			<div className="post-list-item--inner">
+				<input
+					checked={ isSelected }
+					className="screen-reader-text"
+					id={ `select-post-${post.id}` }
+					type="checkbox"
+					onChange={ () => onToggleSelected() }
+				/>
+				<h2 dangerouslySetInnerHTML={ { __html: post.title.rendered } } />
+				<div className="post-list-item--meta">
+					{ postTypeObject && ( <span><b>{ __( 'Type:', 'hm-gb-tools' ) }</b> { postTypeObject.labels.singular_name }</span> ) }
+					<span><b>{ __( 'Published:', 'hm-gb-tools' ) }</b> { moment( post.date_gmt ).format( 'Do MMM, YYYY' ) }</span>
+					{ author && ( <span><b>Author:</b> { author.name }</span> ) }
+				</div>
 			</div>
 		</label>
 	</li>
@@ -29,6 +41,7 @@ const PostListItem = ( { post, author, postTypeObject, isSelected, onToggleSelec
 PostListItem.propTypes = {
 	post: PropTypes.object.isRequired,
 	postTypeObject: PropTypes.object,
+	thumbnail: PropTypes.object,
 	isSelected: PropTypes.bool,
 	onToggleSelected: PropTypes.func.isRequired,
 };

--- a/js/post-select/components/selection-item.js
+++ b/js/post-select/components/selection-item.js
@@ -8,20 +8,32 @@ import SelectionListItemAction from './selection-item-action';
 
 const { Spinner } = wp.components;
 
-const SelectionListItem = ( { post, author, postTypeObject, isSelected, actions } ) => (
-	<li className={ classNames( 'post-list-item', { 'post-list-item--selected': isSelected } ) }>
+const SelectionListItem = ( { post, thumbnail, author, postTypeObject, isSelected, actions } ) => (
+	<li className={ classNames( 'post-list-item post-list-item--selection', {
+		'post-list-item--selected': isSelected,
+		'post-list-item--has-thumbnail': thumbnail,
+	} ) }>
 		{ post ? (
 			<Fragment>
-				<h2 dangerouslySetInnerHTML={ { __html: post.title.rendered } } />
-				<div className="post-list-item--meta">
-					{ postTypeObject && <span key="meta-type"><b>Type:</b> { postTypeObject.labels.name }</span> }
-					<span key="meta-published"><b>Published:</b> { moment( post.date_gmt ).format( 'Do MMM, YYYY' ) }</span>
-					{ author && ( <span><b>Author:</b> { author.name }</span> ) }
-				</div>
-				<div className="post-list-item-actions">
-					{ actions.map( action => (
-						<SelectionListItemAction key={ action.id } { ...action } />
-					) ) }
+				{ thumbnail
+					? <img
+						alt={ post.title.rendered }
+						className="post-list-item--image"
+						src={ thumbnail.media_details.sizes.thumbnail.source_url }
+					/>
+					: '' }
+				<div className="post-list-item--inner">
+					<h2 dangerouslySetInnerHTML={ { __html: post.title.rendered } } />
+					<div className="post-list-item--meta">
+						{ postTypeObject && <span key="meta-type"><b>Type:</b> { postTypeObject.labels.name }</span> }
+						<span key="meta-published"><b>Published:</b> { moment( post.date_gmt ).format( 'Do MMM, YYYY' ) }</span>
+						{ author && ( <span><b>Author:</b> { author.name }</span> ) }
+					</div>
+					<div className="post-list-item-actions">
+						{ actions.map( action => (
+							<SelectionListItemAction key={ action.id } { ...action } />
+						) ) }
+					</div>
 				</div>
 			</Fragment>
 		) : (
@@ -32,6 +44,7 @@ const SelectionListItem = ( { post, author, postTypeObject, isSelected, actions 
 
 SelectionListItem.propTypes = {
 	post: PropTypes.object,
+	thumbnail: PropTypes.object,
 	isSelected: PropTypes.bool,
 	actions: PropTypes.array,
 };

--- a/js/post-select/containers/post-list-item.js
+++ b/js/post-select/containers/post-list-item.js
@@ -12,4 +12,5 @@ export default withSelect( ( select, ownProps ) => ( {
 	...ownProps,
 	author: select( 'core' ).getAuthors().find( a => ownProps.post.author.id === a.id ),
 	postTypeObject: select( 'core' ).getEntityRecord( 'root', 'postType', ownProps.post.type ),
+	thumbnail: ownProps.post.thumbnail ? select( 'core' ).getMedia( ownProps.post.thumbnail ) : null,
 } ) )( PostListItem );

--- a/js/post-select/containers/selection-item.js
+++ b/js/post-select/containers/selection-item.js
@@ -12,4 +12,5 @@ export default withSelect( ( select, ownProps ) => ( {
 	...ownProps,
 	author: select( 'core' ).getAuthors().find( a => ownProps.post.author.id === a.id ),
 	postTypeObject: select( 'core' ).getEntityRecord( 'root', 'postType', ownProps.post.type ),
+	thumbnail: ownProps.post.thumbnail ? select( 'core' ).getMedia( ownProps.post.thumbnail ) : null,
 } ) )( SelectionItem );


### PR DESCRIPTION
This adds the option for a thumbnail in the post select screen. The default is for there to be no thumbnail. To add one, use the filter `hm_gb_tools_item_thumbnail_id` i.e.:

```php
add_filter( 'hm_gb_tools_item_thumbnail_id', function( $id, $post ) {
  return $post->_thumbnail_id;
}, 10, 2 );
```

This allows for a great deal of latitude w/r/t how thumbnails are determined.

Some minor changes to the HTML structure and styles were necessary. On other projects that use this package and are tightly coupled to the structure or styles, this could constitute a breaking change.

Note: This feature was added to a fork of this plugin used in another project, so I'm pushing it back upstream.