### PR TITLE
Add 'switch' behavior for single-post-max

### DIFF
--- a/js/post-select/containers/post-select-modal.js
+++ b/js/post-select/containers/post-select-modal.js
@@ -102,7 +102,10 @@ class PostSelectModalContainer extends React.Component {
 		if ( index >= 0 ) {
 			this.setState( { selection: deleteAtIndex( selection, index ) } );
 		} else {
-			if ( maxPosts && selection.length >= maxPosts ) {
+			if ( maxPosts && maxPosts === 1 ) {
+				// Special "switch" behavior for single-post-max
+				this.setState( { selection: [ post ] } );
+			} else if ( maxPosts && selection.length >= maxPosts ) {
 				/* translators: %d is total number of posts. */
 				alert( sprintf( __( 'Max number %d reached.', 'hm-gb-tools' ), maxPosts ) );
 				return;


### PR DESCRIPTION
When `maxPosts: 1`, the post-selection behavior isn't intuitive: Once a single post has been selected, the user must manually de-select that post before switching to another. This makes sense for multiple selections, for for a single selection it might make more sense that the current selection is switched to whatever post is clicked, without require de-selection first. This PR implements that change.

This would change the behavior someone familiar with this package would expect, which may constitute a breaking change.

Note: This feature was added to a fork of this plugin used in another project, so I'm pushing it back upstream.