### PR TITLE
Fix filter value display

### DIFF
--- a/js/post-select/containers/term-select-form-field.js
+++ b/js/post-select/containers/term-select-form-field.js
@@ -93,6 +93,7 @@ class TermSelect extends React.Component {
 		this.setState( {
 			search: null,
 			page: 1,
+			value,
 		} );
 		onChange( ( value || [] ).map( option => option.value ) );
 	}


### PR DESCRIPTION
After #80, the filter display does not display correctly. This is because the value is now passed on from `state`, but it's never updated.

This PR fixes that.