### PR TITLE
Fix CurrentSelection for multiple post types

### DIFF
--- a/js/current-selection/index.js
+++ b/js/current-selection/index.js
@@ -2,14 +2,26 @@ import wp from 'wp';
 
 import CurrentSelection from './components/current-selection';
 
-const { withSelect } = wp.data;
+const { withSelect, dispatch } = wp.data;
+
+dispatch( 'core' ).addEntities( [
+	{
+		name: 'post-select',
+		kind: 'hm-gb-tools/v1',
+		baseURL: '/hm-gb-tools/v1/post-select',
+	},
+] );
 
 export default withSelect( ( select, ownProps ) => {
 	const { getEntityRecords } = select( 'core' );
 	const { postIds, postType } = ownProps;
-	const posts = getEntityRecords( 'postType', postType, {
+	const postTypes = Array.isArray( postType ) ? postType : [ postType ];
+	const posts = getEntityRecords( 'hm-gb-tools/v1', 'post-select', {
 		include: postIds,
+		per_page: postIds.length,
+		types: postTypes,
 		orderby: 'include',
+		context: 'view',
 	} ) || [];
 
 	return {


### PR DESCRIPTION
Trying to fix #86 by registering the custom post select endpoint with `wp.data` and then using it with `getEntityRecords()`. I think this approach can be used for browsing posts too.