### PR TITLE
Correctly filter by post type when searching posts

### DIFF
--- a/js/post-select/components/browse-filters.js
+++ b/js/post-select/components/browse-filters.js
@@ -47,7 +47,8 @@ const PostBrowseFilters = ( {
 				placeholder={ __( 'Filter by Post Type', 'hm-gb-tools' ) }
 				onChange={ type => onUpdateFilters( {
 					...value,
-					type,
+					// Convert type option objects to their post type slug.
+					type: type.map( ( { value } ) => value ),
 				} ) }
 			/>
 		) }


### PR DESCRIPTION
Setting the `type` filter based on the value passed to the onChange callback sets the filter to an array of `{ label, value }` objects. When these are passed in the API request, they are not recognized as a valid value for the "type" parameter, and are stripped. We need to set the filter to an array of only the `value` parameter so that queries can be correctly filtered by post type.