### PR TITLE
Restore the specified postType list when clearing type filter

### DIFF
--- a/js/post-select/containers/browse.js
+++ b/js/post-select/containers/browse.js
@@ -46,7 +46,7 @@ class PostSelectBrowse extends React.Component {
 			per_page: 25,
 		};
 
-		if ( ! query.type ) {
+		if ( ! query.type || ! query.type.length ) {
 			query.type = Array.isArray( postType ) ? postType : [ postType ];
 		}
 


### PR DESCRIPTION
Because the query.type property is still an empty array when the filter is cleared in the UI, the `!` falsiness check fails and the array never again gets reset to the provided list of post types. Checking for an empty array if the property does exist fixes #90.