### PR TITLE
Reset PostSelect current page when filters are changed

### DIFF
--- a/js/post-select/containers/browse.js
+++ b/js/post-select/containers/browse.js
@@ -1,5 +1,6 @@
 /* global wp */
 
+import _isEqual from 'lodash/isequal';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -108,8 +109,13 @@ class PostSelectBrowse extends React.Component {
 		);
 	}
 
-	applyFilters( filters ) {
-		this.setState( { filters }, () => this.fetchPosts() );
+	applyFilters( newFilters ) {
+		const { filters, page } = this.state;
+		const didFiltersChange = ! _isEqual( filters, newFilters );
+		this.setState( {
+			filters: newFilters,
+			page: didFiltersChange ? 1 : page,
+		}, () => this.fetchPosts() );
 	}
 }
 


### PR DESCRIPTION
This PR fixes #95 by adding a lodash `isEqual` check when applying filters and setting the page back to 1 if it is found that the filters have changed.

This may be tested by going to any page N>1 on the PostSelect results and then changing the search query or any of the categories. It should now go back to page 1, with "Previous page" no longer being an option.