### PR TITLE
Version bump to 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-gutenberg-tools",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "scripts": {
     "build": "webpack --config=.config/webpack.config.prod.js",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name:  HM Gutenberg Tools Plugin
 Plugin URI:   https://hmn.md
 Description:  Tools for Gutenberg.
-Version:      1.6.0
+Version:      1.6.1
 Author:       Human Made Limited
 Author URI:   https://hmn.md
 License:      GPL2


### PR DESCRIPTION
PR version bumps to 1.6.1 - This is done as a separate PR because of the previous merge being done by an external PR.