### PR TITLE
99 - Add actions to make it possible to modify the query

### DIFF
--- a/inc/endpoints/class-post-select-controller.php
+++ b/inc/endpoints/class-post-select-controller.php
@@ -140,7 +140,12 @@ class Post_Select_Controller extends WP_REST_Controller {
 
 		$query_args = apply_filters( 'hm_gb_tools_post_select_query_args', $query_args );
 
+		do_action( 'hm_gb_tools_post_select_before_query' );
+
 		$query = new WP_Query( $query_args );
+
+		do_action( 'hm_gb_tools_post_select_after_query' );
+
 		$posts = [];
 
 		foreach ( $query->posts as $post ) {

--- a/inc/endpoints/class-post-select-controller.php
+++ b/inc/endpoints/class-post-select-controller.php
@@ -140,11 +140,11 @@ class Post_Select_Controller extends WP_REST_Controller {
 
 		$query_args = apply_filters( 'hm_gb_tools_post_select_query_args', $query_args );
 
-		do_action( 'hm_gb_tools_post_select_before_query' );
+		do_action( 'hm_gb_tools_post_select_before_query', $query_args );
 
 		$query = new WP_Query( $query_args );
 
-		do_action( 'hm_gb_tools_post_select_after_query' );
+		do_action( 'hm_gb_tools_post_select_after_query', $query_args );
 
 		$posts = [];
 

--- a/inc/endpoints/class-post-select-controller.php
+++ b/inc/endpoints/class-post-select-controller.php
@@ -90,7 +90,7 @@ class Post_Select_Controller extends WP_REST_Controller {
 	 * @param WP_Query $wp_query
 	 * @return string The modified SQL
 	 */
-	function search_by_title_only( $search, &$wp_query ): string {
+	public function search_by_title_only( $search, &$wp_query ): string {
 		global $wpdb;
 
 		if ( empty( $search ) ) {
@@ -186,14 +186,14 @@ class Post_Select_Controller extends WP_REST_Controller {
 
 		$query_args = apply_filters( 'hm_gb_tools_post_select_query_args', $query_args );
 
-		if ( $query_args->search_by_title_only ) {
-			add_filter( 'posts_search', __NAMESPACE__ . '\\search_by_title_only', 10, 2 );
+		if ( $query_args['search_by_title_only'] ) {
+			add_filter( 'posts_search', [ $this, 'search_by_title_only' ], 10, 2 );
 		}
 
 		$query = new WP_Query( $query_args );
 
-		if ( $query_args->search_by_title_only ) {
-			add_filter( 'posts_search', __NAMESPACE__ . '\\search_by_title_only', 10, 2 );
+		if ( $query_args['search_by_title_only'] ) {
+			add_filter( 'posts_search', [ $this, 'search_by_title_only' ], 10, 2 );
 		}
 
 		$posts = [];

--- a/inc/endpoints/class-post-select-controller.php
+++ b/inc/endpoints/class-post-select-controller.php
@@ -193,7 +193,7 @@ class Post_Select_Controller extends WP_REST_Controller {
 		$query = new WP_Query( $query_args );
 
 		if ( $query_args['search_by_title_only'] ) {
-			add_filter( 'posts_search', [ $this, 'search_by_title_only' ], 10, 2 );
+			remove_filter( 'posts_search', [ $this, 'search_by_title_only' ], 10 );
 		}
 
 		$posts = [];


### PR DESCRIPTION
This PR adds the ability to run extra code from other plugins or theme before and after the query to search for posts. See ticket #99 description for context as to why this may be useful.