### PR TITLE
101 - Fix date label not being cleared when both selected dates are unset

### DIFF
--- a/js/post-select/components/form-field-dates.js
+++ b/js/post-select/components/form-field-dates.js
@@ -38,6 +38,8 @@ const FormFieldDates = ( { onUpdateFilters, value } ) => {
 					`${__( 'Published between', 'hm-gb-tools' )} ${filtersUpdate.after} ${__( 'and', 'hm-gb-tools' )} ${filtersUpdate.before}`
 				);
 			}
+		} else {
+			setSelectedDateRange( '' );
 		}
 
 		onUpdateFilters( filtersUpdate );


### PR DESCRIPTION
#101 

There is a bug where the label above the "Edit date filter" button isn't cleared after unsetting dates. Steps to reproduce:

- Click "Edit date filter" button
- Select a date in both date pickers
- Click "Confirm" button
- The label above the "Edit date filter" button should show text that has the two selected dates
- Click "Edit date filter" button again
- Click the two "Unset" buttons for the date pickers
- Click "Confirm" button
- The label above the "Edit date filter" will remain but this shouldn't be the case

### Acceptance criteria

- [ ] The final result of repeating the steps mentioned above should be the label above the "Edit date filter" button will be cleared.