### PR TITLE
Use dev mode when running webpack watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "webpack --config=.config/webpack.config.prod.js",
-    "start": "npm run build -- --watch",
+    "start": "npm run build -- --watch -d",
     "lint": "eslint ./js --fix",
     "test": "jest"
   },


### PR DESCRIPTION
Rather than setting up a full webpack development config - we just run `webpack --watch` which is close enough for working on this project. This rebuilds the code automatically. However a small enhancement to this is to set it to debug mode when doing this so we get more helpful error messages. 