### PR TITLE
Add post status select field

### DIFF
--- a/inc/endpoints/class-post-select-controller.php
+++ b/inc/endpoints/class-post-select-controller.php
@@ -19,6 +19,11 @@ class Post_Select_Controller extends WP_REST_Controller {
 	const PROP_SEARCH = 'search';
 
 	/**
+	 * Status property name.
+	 */
+	const PROP_STATUS = 'status';
+
+	/**
 	 * Include property name.
 	 */
 	const PROP_INCLUDE = 'include';
@@ -37,7 +42,6 @@ class Post_Select_Controller extends WP_REST_Controller {
 	 * Date query after property name.
 	 */
 	const PROP_AFTER = 'after';
-
 
 	/**
 	 * Date query before property name.
@@ -75,7 +79,6 @@ class Post_Select_Controller extends WP_REST_Controller {
 	/**
 	 * Checks if a given request has access to search content.
 	 *
-	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has search access, WP_Error object otherwise.
 	 */
@@ -99,6 +102,7 @@ class Post_Select_Controller extends WP_REST_Controller {
 
 		$query_args = [
 			'ignore_sticky_posts' => true,
+			'post_status' => $request->get_param( self::PROP_STATUS ) ?? 'publish',
 			'post_type' => $request->get_param( self::PROP_TYPE ),
 			'posts_per_page' => $request->get_param( self::PROP_PER_PAGE ),
 			'paged' => $request->get_param( self::PROP_PAGE ),

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -35,6 +35,7 @@ function enqueue_block_editor_assets() {
 	wp_localize_script( 'hm-gb-tools-editor', 'hmGbToolsData', [
 		'restBase' => esc_url_raw( get_rest_url() ),
 		'postSelectEndpoint' => '/hm-gb-tools/v1/post-select',
+		'postStatuses' => get_post_stati( [ 'internal' => false ] ),
 	] );
 
 	wp_set_script_translations( 'hm-gb-tools-editor', 'hm-gb-tools' );

--- a/js/controls/image.js
+++ b/js/controls/image.js
@@ -4,7 +4,7 @@ import wp from 'wp';
 
 const {
 	MediaUpload,
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
 	Button,

--- a/js/post-select/components/browse-filters.js
+++ b/js/post-select/components/browse-filters.js
@@ -10,6 +10,7 @@ import FormFieldSelect from './form-field-select';
 
 const { Button } = wp.components;
 const { __ } = wp.i18n;
+const { postStatuses } = window.hmGbToolsData;
 
 const PostBrowseFilters = ( {
 	formId,
@@ -75,6 +76,23 @@ const PostBrowseFilters = ( {
 				} ) }
 			/>
 		) ) }
+
+		<FormFieldSelect
+			key={ 'status-filter' }
+			fieldId={ `${formId}-status` }
+			label={ __( 'Filter by Status', 'hm-gb-tools' ) }
+			options={
+				Object.entries( postStatuses ).map( ( [ key, label ] ) => ( {
+					label: label.charAt( 0 ).toUpperCase() + label.slice( 1 ),
+					value: key,
+				} ) )
+			}
+			placeholder={ __( 'Filter by Status', 'hm-gb-tools' ) }
+			onChange={ filterValue => onUpdateFilters( {
+				...value,
+				status: filterValue.map( ( { value } ) => value ),
+			} ) }
+		/>
 
 		<Button
 			isPrimary

--- a/js/post-select/components/post-list-item.js
+++ b/js/post-select/components/post-list-item.js
@@ -30,7 +30,8 @@ const PostListItem = ( { post, author, thumbnail, postTypeObject, isSelected, on
 				<h2 dangerouslySetInnerHTML={ { __html: post.title.rendered } } />
 				<div className="post-list-item--meta">
 					{ postTypeObject && ( <span><b>{ __( 'Type:', 'hm-gb-tools' ) }</b> { postTypeObject.labels.singular_name }</span> ) }
-					<span><b>{ __( 'Published:', 'hm-gb-tools' ) }</b> { moment( post.date_gmt ).format( 'Do MMM, YYYY' ) }</span>
+					<span><b>{ __( 'Status:', 'hm-gb-tools' ) }</b> { post.status }</span>
+					<span><b>{ __( 'Published / Last Modified:', 'hm-gb-tools' ) }</b> { moment( post.date_gmt ).format( 'Do MMM, YYYY' ) }</span>
 					{ author && ( <span><b>Author:</b> { author.name }</span> ) }
 				</div>
 			</div>

--- a/js/post-select/components/selection-item.js
+++ b/js/post-select/components/selection-item.js
@@ -7,6 +7,7 @@ import wp from 'wp';
 import SelectionListItemAction from './selection-item-action';
 
 const { Spinner } = wp.components;
+const { __ }  = wp.i18n;
 
 const SelectionListItem = ( { post, thumbnail, author, postTypeObject, isSelected, actions } ) => (
 	<li className={ classNames( 'post-list-item post-list-item--selection', {
@@ -25,8 +26,9 @@ const SelectionListItem = ( { post, thumbnail, author, postTypeObject, isSelecte
 				<div className="post-list-item--inner">
 					<h2 dangerouslySetInnerHTML={ { __html: post.title.rendered } } />
 					<div className="post-list-item--meta">
-						{ postTypeObject && <span key="meta-type"><b>Type:</b> { postTypeObject.labels.name }</span> }
-						<span key="meta-published"><b>Published:</b> { moment( post.date_gmt ).format( 'Do MMM, YYYY' ) }</span>
+						{ postTypeObject && ( <span><b>{ __( 'Type:', 'hm-gb-tools' ) }</b> { postTypeObject.labels.singular_name }</span> ) }
+						<span><b>{ __( 'Status:', 'hm-gb-tools' ) }</b> { post.status }</span>
+						<span><b>{ __( 'Published / Last Modified:', 'hm-gb-tools' ) }</b> { moment( post.date_gmt ).format( 'Do MMM, YYYY' ) }</span>
 						{ author && ( <span><b>Author:</b> { author.name }</span> ) }
 					</div>
 					<div className="post-list-item-actions">


### PR DESCRIPTION
Fixed #130 

Changelog:
- Adding post status field select
- Allow to accept status from the Rest API endpoint
- Add status field in the post list item
- Update deprecated mediaUpload function 

How to test:
- Open the post select modal
- Add Status filter
- And press filter posts
- The post list result should reflect the selected filter


https://github.com/humanmade/hm-gutenberg-tools/assets/656006/52726bf8-f8fb-4fd0-acbf-6599b3446a3c


