### PR TITLE
Correctly capitalize import of isEqual to fix build on case-sensitive FS

### DIFF
--- a/js/post-select/containers/browse.js
+++ b/js/post-select/containers/browse.js
@@ -1,6 +1,6 @@
 /* global wp */
 
-import _isEqual from 'lodash/isequal';
+import _isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 import React from 'react';
 


### PR DESCRIPTION
On case-sensitive filesystems, trying to import this as `isequal` causes a build error.

Separately, as a new issue in the future, we should consider pulling out the `lodash` dependency in favor of using individual packages ([`lodash.isequal`](https://www.npmjs.com/package/lodash.isequal) for example)