### PR TITLE
Bump version to v1.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ The script will sync the the build branch with main, build assets and commit the
 
 ## Changelog
 
+### v1.7.3
+
+* Restore built asset files not included in v1.7.2 due to release process error.
+
 ### v1.7.2
 
 * Upgraded dependencies for enhanced performance, security and stability.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hm-gutenberg-tools",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "private": true,
   "scripts": {
     "build": "webpack --config=.config/webpack.config.prod.js",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name:  HM Gutenberg Tools Plugin
  * Plugin URI:   https://hmn.md
  * Description:  Tools for Gutenberg.
- * Version:      1.7.2
+ * Version:      1.7.3
  * Author:       Human Made Limited
  * Author URI:   https://hmn.md
  * License:      GPL2


### PR DESCRIPTION
It looks like the `v1.7.2` tag was created on `main`, instead of being created automatically by the `release.sh` script -- that caused the 1.7.2 release to go live without the built files. This could cause downstream errors so I've prepared to release v1.7.3 with no changes other than the restoration of the built files.

Process:

- PR review
- PR merge
- On an updated `main` branch in a local environment, run `./release.sh v1.7.3`, which should create the tag
- Double-check the built branch received the update and tag
- Update releases list