### PR TITLE
Add warning message RE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Human Made Gutenberg Tools
 ==========================
 
+> [!WARNING]  
+> This project is no longer actively developed. It is recommended that you the components from our [Block Editor Components library instead](https://github.com/humanmade/block-editor-components).  
+
 A place to bundle useful reusable Gutenberg components and other tools.
 
 ## What does this include?


### PR DESCRIPTION
This project is quite old and has really been superseded by the [HM Block Editor Components repo](https://github.com/humanmade/block-editor-components). 

That project is easier to use as the JS components be more easily included in your code. It has no dependencies and is not a plugin that needs activating etc. Generally it's just more modern.

However there isn't quite feature parity. Missing things

* Link Control - because this is basically just some CSS on top of cores `URLInput`
* Post picker - features that rely on PHP. Including searching multiple post types as this uses a custom REST API endpoint for this. 

I think just displaying a warning for now is enough - just to push new users over to that project instead. We can continue to make fixes as this is still widely used. 