### PR TITLE
Fix rendered post title

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ The script will sync the the build branch with main, build assets and commit the
 
 ## Changelog
 
+### v1.7.4
+
+* Fix post-select endpoint response, where the rendered title should be rendered with `get_the_title`
+
 ### v1.7.3
 
 * Restore built asset files not included in v1.7.2 due to release process error.

--- a/inc/endpoints/class-post-select-controller.php
+++ b/inc/endpoints/class-post-select-controller.php
@@ -175,7 +175,7 @@ class Post_Select_Controller extends WP_REST_Controller {
 			'id' => $post->ID,
 			'title' => [
 				'raw'      => $post->post_title,
-				'rendered' => $post->post_title,
+				'rendered' => get_the_title( $post ),
 			],
 			'type' => $post->post_type,
 			'date' => $this->prepare_date_response( $post->post_date_gmt, $post->post_date ),

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name:  HM Gutenberg Tools Plugin
  * Plugin URI:   https://hmn.md
  * Description:  Tools for Gutenberg.
- * Version:      1.7.3
+ * Version:      1.7.4
  * Author:       Human Made Limited
  * Author URI:   https://hmn.md
  * License:      GPL2


### PR DESCRIPTION
Bug fix for post-select endpoint:

* Updated the `prepare_item_for_response` method in `class-post-select-controller.php` to use `get_the_title( $post )` for the `rendered` title, ensuring the title is properly rendered in the API response. This allow the downstream app to change the title with a core filter.


Also This pull request bump to version 1.7.4
